### PR TITLE
Fix imports and prefixes

### DIFF
--- a/src/ontology/edit/catalog-v001.xml
+++ b/src/ontology/edit/catalog-v001.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo.omn" uri="https://raw.githubusercontent.com/OpenEnergyPlatform/ontology/releases-v2.2.0/src/ontology/oeo.omn"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo.omn" uri="file:/C:/Users/stappel/Documents/Ontologies/OEO/src/ontology/oeo.omn"/>
-    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/2.1.0/oeo.omn" uri="https://openenergy-platform.org/ontology/oeo/releases/oeo.omn"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base=""/>
 </catalog>

--- a/src/ontology/edit/catalog-v001.xml
+++ b/src/ontology/edit/catalog-v001.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo.omn" uri="https://raw.githubusercontent.com/OpenEnergyPlatform/ontology/releases-v2.2.0/src/ontology/oeo.omn"/>
+    <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/dev/oeo.omn" uri="file:/C:/Users/stappel/Documents/Ontologies/OEO/src/ontology/oeo.omn"/>
     <uri id="Imports Wizard Entry" name="http://openenergy-platform.org/ontology/oeo/releases/2.1.0/oeo.omn" uri="https://openenergy-platform.org/ontology/oeo/releases/oeo.omn"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base=""/>
 </catalog>

--- a/src/ontology/edit/oeo-extended.omn
+++ b/src/ontology/edit/oeo-extended.omn
@@ -13,7 +13,6 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 Ontology: <http://openenergy-platform.org/ontology/oeo-extended/>
 
 Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo.omn>
-Import: <http://openenergy-platform.org/ontology/oeo/releases/2.1.0/oeo.omn>
 
 Annotations: 
     dc:description "The Open Energy Ontology Extended (OEOX) extends the Open Energy Ontology. It contains compositions of terms that are too specific for the OEO.",

--- a/src/ontology/edit/oeo-extended.omn
+++ b/src/ontology/edit/oeo-extended.omn
@@ -1,5 +1,6 @@
 Prefix: : <http://openenergy-platform.org/ontology/oeo-extended/>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
+Prefix: dct: <http://purl.org/dc/terms/>
 Prefix: oeo: <http://openenergy-platform.org/ontology/oeo/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -16,19 +17,19 @@ Import: <http://openenergy-platform.org/ontology/oeo/releases/2.1.0/oeo.omn>
 
 Annotations: 
     dc:description "The Open Energy Ontology Extended (OEOX) extends the Open Energy Ontology. It contains compositions of terms that are too specific for the OEO.",
-    <http://purl.org/dc/terms/license> "http://creativecommons.org/publicdomain/zero/1.0/",
-    <http://purl.org/dc/terms/title> "Open Energy Ontology Extended (OEOX)"
+    dct:license "http://creativecommons.org/publicdomain/zero/1.0/",
+    dct:title "Open Energy Ontology Extended (OEOX)"
 
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
 
     
-AnnotationProperty: <http://purl.org/dc/terms/license>
-
-    
-AnnotationProperty: <http://purl.org/dc/terms/title>
-
-    
 AnnotationProperty: dc:description
+
+    
+AnnotationProperty: dct:license
+
+    
+AnnotationProperty: dct:title
 
     
 AnnotationProperty: rdfs:label

--- a/src/ontology/edit/oeo-extended.omn
+++ b/src/ontology/edit/oeo-extended.omn
@@ -11,6 +11,7 @@ Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
 Ontology: <http://openenergy-platform.org/ontology/oeo-extended/>
 
+Import: <http://openenergy-platform.org/ontology/oeo/dev/oeo.omn>
 Import: <http://openenergy-platform.org/ontology/oeo/releases/2.1.0/oeo.omn>
 
 Annotations: 

--- a/src/ontology/edit/oeo-extended.omn
+++ b/src/ontology/edit/oeo-extended.omn
@@ -1,4 +1,4 @@
-Prefix: : <https://openenergy-platform.org/ontology/oeo-extended/>
+Prefix: : <http://openenergy-platform.org/ontology/oeo-extended/>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: oeo: <http://openenergy-platform.org/ontology/oeo/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
@@ -48,7 +48,7 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
 ObjectProperty: oeo:OEO_00020056
 
     
-Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010000>
+Class: OEOX_00010000
 
     Annotations: 
         rdfs:label "final energy consumption of gasoline for transport"@en
@@ -60,7 +60,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010000>
              and (<http://purl.obolibrary.org/obo/RO_0000057> some oeo:OEO_00000183)))
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010001>
+Class: OEOX_00010001
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emisson scenario report is a study report that is about one or more CO2 emission scenarios.",
@@ -71,7 +71,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010001>
          and (<http://purl.obolibrary.org/obo/IAO_0000136> some oeo:OEO_00020321)
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010002>
+Class: OEOX_00010002
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind turbine space requirement is a specific space requirement that is a quantity value of one or more wind energy converting units.",
@@ -85,7 +85,7 @@ Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010002>
         oeo:OEO_00020141
     
     
-Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010003>
+Class: OEOX_00010003
 
     Annotations: 
         rdfs:label "GHG emission scenario report"@en

--- a/src/ontology/edit/oeo-extended.omn
+++ b/src/ontology/edit/oeo-extended.omn
@@ -1,6 +1,6 @@
 Prefix: : <https://openenergy-platform.org/ontology/oeo-extended/>
 Prefix: dc: <http://purl.org/dc/elements/1.1/>
-Prefix: dct: <http://purl.org/dc/terms/>
+Prefix: oeo: <http://openenergy-platform.org/ontology/oeo/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -15,19 +15,19 @@ Import: <http://openenergy-platform.org/ontology/oeo/releases/2.1.0/oeo.omn>
 
 Annotations: 
     dc:description "The Open Energy Ontology Extended (OEOX) extends the Open Energy Ontology. It contains compositions of terms that are too specific for the OEO.",
-    dct:license "http://creativecommons.org/publicdomain/zero/1.0/",
-    dct:title "Open Energy Ontology Extended (OEOX)"
+    <http://purl.org/dc/terms/license> "http://creativecommons.org/publicdomain/zero/1.0/",
+    <http://purl.org/dc/terms/title> "Open Energy Ontology Extended (OEOX)"
 
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
 
     
+AnnotationProperty: <http://purl.org/dc/terms/license>
+
+    
+AnnotationProperty: <http://purl.org/dc/terms/title>
+
+    
 AnnotationProperty: dc:description
-
-    
-AnnotationProperty: dct:license
-
-    
-AnnotationProperty: dct:title
 
     
 AnnotationProperty: rdfs:label
@@ -39,13 +39,13 @@ Datatype: rdf:PlainLiteral
 Datatype: xsd:string
 
     
-ObjectProperty: <http://openenergy-platform.org/ontology/oeo/OEO_00020056>
-
-    
 ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000057>
+
+    
+ObjectProperty: oeo:OEO_00020056
 
     
 Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010000>
@@ -54,10 +54,10 @@ Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010000>
         rdfs:label "final energy consumption of gasoline for transport"@en
     
     EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00050016>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00020056> some 
-            (<http://openenergy-platform.org/ontology/oeo/OEO_00140003>
-             and (<http://purl.obolibrary.org/obo/RO_0000057> some <http://openenergy-platform.org/ontology/oeo/OEO_00000183>)))
+        oeo:OEO_00050016
+         and (oeo:OEO_00020056 some 
+            (oeo:OEO_00140003
+             and (<http://purl.obolibrary.org/obo/RO_0000057> some oeo:OEO_00000183)))
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010001>
@@ -67,8 +67,8 @@ Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010001>
         rdfs:label "CO2 emission scenario report"@en
     
     EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020012>
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020321>)
+        oeo:OEO_00020012
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some oeo:OEO_00020321)
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010002>
@@ -78,11 +78,11 @@ Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010002>
         rdfs:label "wind turbine space requirement"@en
     
     EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020141>
-         and (<http://openenergy-platform.org/ontology/oeo/OEO_00020056> some <http://openenergy-platform.org/ontology/oeo/OEO_00000044>)
+        oeo:OEO_00020141
+         and (oeo:OEO_00020056 some oeo:OEO_00000044)
     
     SubClassOf: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020141>
+        oeo:OEO_00020141
     
     
 Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010003>
@@ -91,29 +91,31 @@ Class: <http://openenergy-platform.org/ontology/oeo-extended/OEOX_00010003>
         rdfs:label "GHG emission scenario report"@en
     
     EquivalentTo: 
-        <http://openenergy-platform.org/ontology/oeo/OEO_00020012>
-         and (<http://purl.obolibrary.org/obo/IAO_0000136> some <http://openenergy-platform.org/ontology/oeo/OEO_00020317>)
+        oeo:OEO_00020012
+         and (<http://purl.obolibrary.org/obo/IAO_0000136> some oeo:OEO_00020317)
     
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000044>
+Class: oeo:OEO_00000044
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00000183>
+Class: oeo:OEO_00000183
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020012>
+Class: oeo:OEO_00020012
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020141>
+Class: oeo:OEO_00020141
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020317>
+Class: oeo:OEO_00020317
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00020321>
+Class: oeo:OEO_00020321
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00050016>
+Class: oeo:OEO_00050016
 
     
-Class: <http://openenergy-platform.org/ontology/oeo/OEO_00140003>
+Class: oeo:OEO_00140003
+
+    


### PR DESCRIPTION
I changed the import of oeo to https://raw.githubusercontent.com/OpenEnergyPlatform/ontology/releases-v2.2.0/src/ontology/oeo.omn. This is is just a temporal solution though, but I need to fix it now somehow.

Further, I fixed/added prefixes for oeox and oeo.
